### PR TITLE
Updates build context for agents to `openapi-demo` branch.

### DIFF
--- a/AliceFaberAcmeDemo/docker/docker-compose.yml
+++ b/AliceFaberAcmeDemo/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     faber-agent:
         command: ['faber --port 8020']
         build:
-            context: https://github.com/hyperledger/aries-cloudagent-python.git
+            context: https://github.com/petridishdev/aries-cloudagent-python.git#openapi-demo
             dockerfile: ./docker/Dockerfile.demo
         ports:
             - 8020-8027:8020-8027
@@ -20,7 +20,7 @@ services:
     alice-agent:
         command: ['alice --port 8030']
         build:
-            context: https://github.com/hyperledger/aries-cloudagent-python.git
+            context: https://github.com/petridishdev/aries-cloudagent-python.git#openapi-demo
             dockerfile: ./docker/Dockerfile.demo
         ports:
             - 8030-8037:8030-8037
@@ -35,7 +35,7 @@ services:
     acme-agent:
         command: ['acme --port 8040']
         build:
-            context: https://github.com/petridishdev/aries-cloudagent-python.git#acme-complete
+            context: https://github.com/petridishdev/aries-cloudagent-python.git#openapi-demo
             dockerfile: ./docker/Dockerfile.demo
         ports:
             - 8040-8047:8040-8047


### PR DESCRIPTION
Signed-off-by: Akiff Manji <akiff.manji@gmail.com>

Build context for agents was updated to reference a static branch (openapi-demo) of an [aries-cloudagent-python](https://github.com/petridishdev/aries-cloudagent-python) fork. The branch was created as a static reference to demo agents, to prevent controllers from breaking in case agents in the upstream repository (original build context) were updated.

This PR fixes issue #10 