### PR TITLE
fixed typo in README.md

### DIFF
--- a/AliceFaberAcmeDemo/README.md
+++ b/AliceFaberAcmeDemo/README.md
@@ -35,7 +35,7 @@ In your browser, go to a docker playground service [Play with Docker](https://la
 On the [Play with Docker](https://labs.play-with-docker.com/) title screen, click "Start". On the next screen, click (in the left menu) "+Add a new instance". That will start up a terminal in your browser. Run the following commands to start the Web Demo:
 
 ```
-$ git clone https://github.com/hyperleger/aries-acapy-controllers.git
+$ git clone https://github.com/hyperledger/aries-acapy-controllers.git
 $ cd aries-acapy-controllers/AliceFaberAcmeDemo
 $ LEDGER_URL=http://dev.greenlight.bcovrin.vonx.io ./run_demo webstart
 


### PR DESCRIPTION
wrong url:
git clone https://github.com/hyperleger/aries-acapy-controllers.git
fixed to 
git clone https://github.com/hyperledger/aries-acapy-controllers.git