### PR TITLE
Allows setting agent host for Alice

### DIFF
--- a/AliceFaberAcmeDemo/controllers/alice-controller/Dockerfile
+++ b/AliceFaberAcmeDemo/controllers/alice-controller/Dockerfile
@@ -5,7 +5,7 @@ COPY package*.json /app/
 RUN npm install
 COPY . .
 ARG RUNMODE
-ARG ALICE_AGENT_HOST=${ALICE_AGENT_HOST-"localhost"}
+ARG ALICE_AGENT_HOST=${ALICE_AGENT_HOST:-"localhost"}
 ENV RUNMODE=${RUNMODE} ALICE_AGENT_HOST=${ALICE_AGENT_HOST}
 RUN npm run build
 

--- a/AliceFaberAcmeDemo/controllers/alice-controller/Dockerfile
+++ b/AliceFaberAcmeDemo/controllers/alice-controller/Dockerfile
@@ -5,7 +5,7 @@ COPY package*.json /app/
 RUN npm install
 COPY . .
 ARG RUNMODE
-ARG ALICE_AGENT_HOST=localhost
+ARG ALICE_AGENT_HOST=${ALICE_AGENT_HOST-"localhost"}
 ENV RUNMODE=${RUNMODE} ALICE_AGENT_HOST=${ALICE_AGENT_HOST}
 RUN npm run build
 

--- a/AliceFaberAcmeDemo/controllers/alice-controller/src/app/services/interceptor.service.ts
+++ b/AliceFaberAcmeDemo/controllers/alice-controller/src/app/services/interceptor.service.ts
@@ -12,7 +12,7 @@ export class InterceptorService implements HttpInterceptor {
   formattedAgentUrl: string;
 
   constructor() {
-    this.hostname = $ENV.RUNMODE === 'pwd' ? $ENV.ALICE_AGENT_HOST : 'localhost';
+    this.hostname = $ENV.ALICE_AGENT_HOST || 'localhost';
     this.port = $ENV.RUNMODE === 'pwd' ? '' : ':8031';
     this.formattedAgentUrl = `http://${this.hostname}` + this.port;
     console.log('Agent is running on: ' + this.formattedAgentUrl);


### PR DESCRIPTION
Alice Controller default's to `localhost` for the Agent hostname, which prevents the application from being deployed in a cloud service.

This fix allows a user to set the `ALICE_AGENT_HOST` environment variable when running the `./run_demo webstart` command which will substitute out the default `localhost` agent hostname to a user's preference.