### PR TITLE
AWS Instructions

### DIFF
--- a/AliceFaberAcmeDemo/README.md
+++ b/AliceFaberAcmeDemo/README.md
@@ -10,6 +10,8 @@ _See [Note to Developers](#note-to-developers) if you are a developer looking fo
   - [Table of Contents](#table-of-contents)
     - [Running in a Browser](#running-in-a-browser)
     - [Running With Docker](#running-with-docker)
+    - [Running in the Cloud With AWS](#running-in-the-cloud-with-aws)
+      - [Opening Ports](#opening-ports)
     - [Running Locally](#running-locally)
       - [Prerequisites](#prerequisites)
         - [VON Network](#von-network)

--- a/AliceFaberAcmeDemo/README.md
+++ b/AliceFaberAcmeDemo/README.md
@@ -49,6 +49,26 @@ _If you are interested in studying the APIs exposed by agents, click on the `802
 
 This will be the easiest setup option.
 
+### Running in the Cloud With AWS
+
+_Note: These instructions apply when running the demo in a VPS or on your own server host and assumes you have already set up a cloud/server instance for running the demo._
+
+Running the demo in an AWS instance is almnost exactly the same as running the demo locally with docker, however there is a caveat to getting the Alice controller to successfully connect to its agent.
+
+Unlike Faber and Acme demo controllers, which are server-side applications (and are therefore hosted in the same network as their respective agents), Alice controller is an Angular application, that runs directly in your browser on your local machine. By default, controllers assume agents are running in the same network as the controllers (i.e `localhost`). However, `localhost` on your machine will not be the same as `localhost` on your AWS instance, therefore you have to explicitly build the Alice controller specifying the location where the Agent is hosted so it can connect and issue Agent API requests.
+
+To do this you can provide an `ALICE_AGENT_HOST` environment variable when executing the `./run_demo` command as such:
+
+```
+$ LEDGER_URL=http://dev.greenlight.bcovrin.vonx.io ALICE_AGENT_HOST=<Your AWS Instance's Public DNS or IPv4> ./run_demo webstart
+```
+
+_Note:_ you may have to destroy any previously built Alice controller docker images so it will rebuild correctly with the correct agent context.
+
+#### Opening Ports
+
+Ensure that you have innbound and outbound rules enabled for the port range 9021-9041 on your AWS instance. Additionally you will need to enable inbound and outbound rules for port 8031 so that Alice controller can communicate with its agent.
+
 ### Running Locally
 
 #### Prerequisites

--- a/AliceFaberAcmeDemo/run_demo
+++ b/AliceFaberAcmeDemo/run_demo
@@ -9,7 +9,7 @@ function web_start() {
 	echo "Starting all agents and controllers, this may take a moment."
 
 	FABER_AGENT_HOST="faber-agent"
-	ALICE_AGENT_HOST="localhost"
+	ALICE_AGENT_HOST=${ALICE_AGENT_HOST:-"localhost"}
 	ACME_AGENT_HOST="acme-agent"
 
 	if [ -z "${PWD_HOST_FQDN}" ]; then
@@ -32,6 +32,8 @@ function web_start() {
 
 	AGENT_URLS="FABER_AGENT_HOST=${FABER_AGENT_HOST} ALICE_AGENT_HOST=${ALICE_AGENT_HOST} ACME_AGENT_HOST=${ACME_AGENT_HOST}"
 	DOCKER_ENV="$AGENT_URLS RUNMODE=${RUNMODE} DOCKERHOST=${DOCKERHOST}"
+
+	echo "Agent Hosts: ${AGENT_URLS}"
 
 	if ! [ -z "$LEDGER_URL" ]; then
 		GENESIS_URL="${LEDGER_URL}/genesis"


### PR DESCRIPTION
Adds instructions for running Alice-Faber-Acme demo in an AWS instance. Additional instructions added for successful connection of Alice controller to Alice agent under the AWS scheme.

Also adds a fix to read the `ALICE_AGEST_HOST` environment variable in the `./run_demo` command to set the agent host parameter correctly when building the Alice controller docker image.