### PR TITLE
Centralize docker host IP script.

### DIFF
--- a/AliceFaberAcmeDemo/run_demo
+++ b/AliceFaberAcmeDemo/run_demo
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
+. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))"
+
 function start_logs() {
 	cd ./docker
 	docker-compose logs -f --tail ${TAIL:-10}
@@ -13,11 +16,7 @@ function web_start() {
 	ACME_AGENT_HOST="acme-agent"
 
 	if [ -z "${PWD_HOST_FQDN}" ]; then
-		if [[ $(uname) == "Linux" ]] ; then
-			DOCKERHOST=$(docker run --rm --net=host eclipse/che-ip)
-		else
-			DOCKERHOST=host.docker.internal
-		fi
+		DOCKERHOST=$(getDockerHost)
 		RUNMODE="docker"
 	else
 		PWD_HOST="${PWD_HOST_FQDN}"


### PR DESCRIPTION
- This is an update to the previous commit to update the support for Docker networking.  The `getDockerHost` has been pulled out and placed in a central location where it can be updated as needed rather than having to update dozens of scripts the next time there is a change.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>