### PR TITLE
Readme steps for local tunnel for Traction demo

### DIFF
--- a/TractionIssuanceDemo/README.md
+++ b/TractionIssuanceDemo/README.md
@@ -9,6 +9,27 @@ Licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
  - [Set up Traction](#Traction)
  - [Run App](#App)
 
+## Tunnel Setup
+As the simple demo application shown here requires listening for webhooks sent back to the app, a prerequisite is for the system the demo app is running on to have a public endpoint to call to.
+
+If running on `localhost` then you will require a secure tunnel to expose the local server.
+
+There are many options for running this on your local computer such as 
+- [Localtunnel](https://theboroer.github.io/localtunnel-www/)
+- [ngrok](https://ngrok.com/)
+- [cloudflared (Cloudflare Tunnel)](https://github.com/cloudflare/cloudflared)
+
+In this example, localtunnel is suggested, as the demo app builds with Node as well.
+
+1. Install Localtunnel with  
+`npm install -g localtunnel`
+2. Start Localtunnel on port 8080 (the port used by the demo app) with  
+`lt --port 8080`
+3. Note the URL given to you by the last command to use in a later step. It will be something like `https://abc-xyz.loca.lt`
+
+**Note:** Your mileage may vary for using secure tunnel public endpoint services based on organizational firewalls or other factors.
+
+
 ## Traction
 1. Go to: https://traction-sandbox-tenant-ui.apps.silver.devops.gov.bc.ca
 2. Click the link:  `Create Request!`
@@ -19,9 +40,9 @@ Licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 7. Add the Tenant ID from the Profile page to the config.json file
 8. Click the connect button to connect to bcovrin-test
 9. Go to the Settings page
-10. Add the url to your computer in the WebHook URL using the port 8080  
-  For example, if your computer is example.com then the URL will be http://example.com:8080
-11. Enter the WebHook Key of: `demo-issuance`
+10. Add the url to your exposed tunnel endpoint in the **WebHook URL** using the port 8080  
+  For example, if Localtunnel gave you `https://abc-xyz.loca.lt` then the Webhook URL will be `https://abc-xyz.loca.lt`
+11. Enter the **WebHook Key** of: `demo-issuance`
 12. Save changes
 13. Go to the API Keys page
 14. Click the Create API Key, give it an alias and submit
@@ -48,6 +69,6 @@ Licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
     &nbsp;&nbsp;&nbsp;false means this app will issue the credential once the user accepts  
   Set the credential data  
   &nbsp;&nbsp;&nbsp;expires should be a date in the future with the format of YYYYMMDD
-2. Make sure your computer is accessible through port 8080
+2. Make sure your computer is accessible through port 8080 (see Tunnel Setup above)
 3. Run: `npm install`
 4. Run: `npm start`

--- a/TractionIssuanceDemo/README.md
+++ b/TractionIssuanceDemo/README.md
@@ -40,7 +40,7 @@ In this example, localtunnel is suggested, as the demo app builds with Node as w
 7. Add the Tenant ID from the Profile page to the config.json file
 8. Click the connect button to connect to bcovrin-test
 9. Go to the Settings page
-10. Add the url to your exposed tunnel endpoint in the **WebHook URL** using the port 8080  
+10. Add the url to your exposed tunnel endpoint in the **WebHook URL**  
   For example, if Localtunnel gave you `https://abc-xyz.loca.lt` then the Webhook URL will be `https://abc-xyz.loca.lt`
 11. Enter the **WebHook Key** of: `demo-issuance`
 12. Save changes


### PR DESCRIPTION
The Traction Demo steps in the readme will not work for running locally unless there's a way to expose the localhost.

Adding instructions here to use Localtunnel, which is very simple to set up and start https://theboroer.github.io/localtunnel-www/

Could use ngrok or other things, but Node/npm is required to start the Traction demo app supplied so it's easy to use Localtunnel in that case. We could also have a dockerfile that starts up everything, but a user would of course need Docker as well for that, so not sure if it's any simpler in that case. Could think of as a future step.

I tested these instructions and it worked a couple times for me on my Windows machine at home at least. Went through connection/issue/pres-req/revoke to my BC Wallet, using Sandbox. 