### PR TITLE
Git ignore node modules built in Traction demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,9 @@ $RECYCLE.BIN/
 
 # Docs build
 _build/
+
+###
+### Node
+###
+
+node_modules/


### PR DESCRIPTION
Traction demo runs an `npm install` so we should gitignore any node modules in this repo.